### PR TITLE
Developing possibilites

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from distutils.core import setup
+import setuptools
 
 classifiers = ['Development Status :: 5 - Production/Stable',
     'Environment :: Console',


### PR DESCRIPTION
Importing setuptools, turns the package able to be compiled for internal developing process.

python setup.py develop

In this case, any modifications inside de code can be tested before any Git pushes.
