### PR TITLE
Add 2015 leap second

### DIFF
--- a/pysolar/time.py
+++ b/pysolar/time.py
@@ -79,6 +79,7 @@ leap_seconds_adjustments = \
       (+1, 0), # 2012
       (0, 0), # 2013
       (0, 0), # 2014
+      (+1, 0), #2015
     ]
 
 def get_leap_seconds(when) :


### PR DESCRIPTION
I noticed that when calculating dates after the last leap second in the
table, a user warning is issued. This is good, as I otherwise would not
have known that leap seconds are handled as a constant.

This patch adds the 2015 leap second to the constant list, bringing it
up to date.