### PR TITLE
get_altitude() changed to GetAltitude() in doc

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -62,7 +62,7 @@ Then, use the solar.GetAltitude() function to calculate the angle between the su
     >>> get_altitude(42.206, -71.382, d)
     24.39867440096082
     >>> d = datetime.datetime(2007, 2, 18, 15, 13, 1, 130320)
-    >>> get_altitude(42.206, -71.382, d)
+    >>> GetAltitude(42.206, -71.382, d)
     20.374937135509537
 
 You can also calculate the azimuth of the sun, as shown below.::


### PR DESCRIPTION
Code snippet used an incorrect (old?) version of function name, which was correctly given elsewhere in text.