### PR TITLE
Add leap second for 2016

### DIFF
--- a/pysolar/time.py
+++ b/pysolar/time.py
@@ -80,7 +80,8 @@ leap_seconds_adjustments = \
       (+1, 0), # 2012
       (0, 0), # 2013
       (0, 0), # 2014
-      (+1, 0), #2015
+      (+1, 0), # 2015
+      (+1, 0), # 2016
     ]
 
 def get_leap_seconds(when) :


### PR DESCRIPTION
Add leap second to 2016 per [IERS Bulletin C](https://hpiers.obspm.fr/iers/bul/bulc/bulletinc.dat), published July 6th 2016.