### PR TITLE
Add Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+    - "3.4"
+    - "3.5"
+    - "3.6"
+    - "3.7-dev"
+script: PYTHONPATH="." python test/testsolar.py

--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,7 @@
 ## Pysolar ##
 
+[![Build Status](https://travis-ci.org/pingswept/pysolar.svg?branch=master)](https://travis-ci.org/pingswept/pysolar)
+
 Pysolar is a collection of Python libraries for simulating the irradiation of any point on earth by the sun. It includes code for extremely precise ephemeris calculations, and more.
 
 # Note: right now, the latest commits of Pysolar don't work with Python 2.x #


### PR DESCRIPTION
Run testcases using [Travis](https://travis-ci.org/). The testcases are automatically executed on pushes + on PRs to ensure the project's testcases pass on Python 3.4 up to 3.7-dev.

* On the main page there is a badge with the current build status ([example](https://github.com/quinox/pysolar/tree/travis-quinox))
* This badge links to the results of Travis ([example](https://travis-ci.org/quinox/pysolar))

One time setup is easy:
* Visit https://travis-ci.org/
* Login through Github OAuth (no account at Travis required)
* Enable testing for *pingswept/pysolar*
* Merge this PR.