### PR TITLE
Make get_elevation and get_azimuth numpy-aware

### DIFF
--- a/pysolar/__init__.py
+++ b/pysolar/__init__.py
@@ -3,4 +3,11 @@ from . import \
     solartime as stime, \
     radiation, \
     util, \
-    solar
+    solar, \
+    numeric
+
+def use_numpy():
+    numeric.use_numpy()
+
+def use_math():
+    numeric.use_math()

--- a/pysolar/elevation.py
+++ b/pysolar/elevation.py
@@ -19,7 +19,6 @@
 
 """
 import warnings
-import math
 from .constants import \
     standard_pressure, \
     standard_temperature, \
@@ -69,7 +68,7 @@ def get_temperature_with_elevation(h, Ts=standard_temperature, Tl=earth_temperat
 def elevation_test():
     print("Elevation(m) Pressure(Pa) Temperature(K)")
     h = 0
-    for i in range(11):
+    for _ in range(11):
         P = get_pressure_with_elevation(h)
         T = get_temperature_with_elevation(h)
         print("%i %i %i" % (h, P, T))

--- a/pysolar/numeric.py
+++ b/pysolar/numeric.py
@@ -1,0 +1,103 @@
+
+#    Copyright François Steinmetz
+#
+#    This file is part of Pysolar.
+#
+#    Pysolar is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Pysolar is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License along
+#    with Pysolar. If not, see <http://www.gnu.org/licenses/>.
+
+
+"""
+Import math functions from either numpy (in order to vectorize operations) or
+builtins math module.
+
+By default, use numpy when available.
+
+To force builtins math module usage when numpy is available:
+    import pysolar
+    pysolar.use_math()
+"""
+
+from math import degrees, cos, sin, radians, tan, pi
+from math import acos, atan, asin, atan2, exp, e
+
+current_mod = 'math'
+
+
+def globals_import_from(module, name, name_as):
+    """
+    Does "from <module> import <name> as <name_as>" (globally)
+    """
+    module = __import__(module, fromlist=[name])
+    globals()[name_as] = getattr(module, name)
+
+
+def where(condition, x, y):
+    """ scalar version of numpy.where """
+    if condition:
+        return x
+    else:
+        return y
+
+
+def all(x):
+    """ scalar version of numpy.all (does nothing) """
+    return x
+
+
+def use_numpy():
+    """
+    Import required functions/constants from numpy
+    """
+    globals_import_from('numpy', 'degrees', 'degrees')
+    globals_import_from('numpy', 'cos', 'cos')
+    globals_import_from('numpy', 'sin', 'sin')
+    globals_import_from('numpy', 'radians', 'radians')
+    globals_import_from('numpy', 'tan', 'tan')
+    globals_import_from('numpy', 'pi', 'pi')
+    globals_import_from('numpy', 'arccos', 'acos')
+    globals_import_from('numpy', 'arctan', 'atan')
+    globals_import_from('numpy', 'arcsin', 'asin')
+    globals_import_from('numpy', 'arctan2', 'atan2')
+    globals_import_from('numpy', 'exp', 'exp')
+    globals_import_from('numpy', 'e', 'e')
+    globals_import_from('numpy', 'where', 'where')
+    globals_import_from('numpy', 'all', 'all')
+    globals()['current_mod'] = 'numpy'
+
+def use_math():
+    """
+    Import required functions/constants from builtins math module
+    """
+    globals_import_from('math', 'degrees', 'degrees')
+    globals_import_from('math', 'cos', 'cos')
+    globals_import_from('math', 'sin', 'sin')
+    globals_import_from('math', 'radians', 'radians')
+    globals_import_from('math', 'tan', 'tan')
+    globals_import_from('math', 'pi', 'pi')
+    globals_import_from('math', 'acos', 'acos')
+    globals_import_from('math', 'atan', 'atan')
+    globals_import_from('math', 'asin', 'asin')
+    globals_import_from('math', 'atan2', 'atan2')
+    globals_import_from('math', 'exp', 'exp')
+    globals_import_from('math', 'e', 'e')
+    globals()['where'] = where
+    globals()['all'] = all
+    globals()['current_mod'] = 'math'
+
+try:
+    import numpy
+    use_numpy()
+except ModuleNotFoundError:
+    pass
+

--- a/pysolar/radiation.py
+++ b/pysolar/radiation.py
@@ -18,7 +18,7 @@
 """Calculate different kinds of radiation components via default values
 
 """
-import math
+from . import numeric as math
 
 def get_air_mass_ratio(altitude_deg):
     # from Masters, p. 412

--- a/pysolar/rest.py
+++ b/pysolar/rest.py
@@ -15,7 +15,7 @@
 #    You should have received a copy of the GNU General Public License along
 #    with Pysolar. If not, see <http://www.gnu.org/licenses/>.
 
-import math
+from . import numeric as math
 from .constants import standard_pressure
 
 # single-scattering albedo used to calculate aerosol scattering transmittance;

--- a/pysolar/simulate.py
+++ b/pysolar/simulate.py
@@ -18,7 +18,7 @@
 """Support functions for horizon calculation
 
 """
-import math
+from . import numeric as math
 import datetime
 from . import constants
 from . import radiation
@@ -27,7 +27,6 @@ from . import solar
 def datetime_range(start_datetime, end_datetime, step_minutes):
     '''yields a sequence of datetimes evenly spaced apart by step_minutes.'''
     step = step_minutes * 60
-    time_list = []
     span = end_datetime - start_datetime
     dt = datetime.timedelta(seconds = step)
     for n in range((span.days * constants.seconds_per_day + span.seconds) // step) :

--- a/pysolar/solar.py
+++ b/pysolar/solar.py
@@ -26,12 +26,13 @@ from . import constants
 from . import solartime as stime
 from . import radiation
 from .tzinfo_check import check_aware_dt
+import pytz
 
 
 def solar_test():
     latitude_deg = 42.364908
     longitude_deg = -71.112828
-    d = datetime.datetime.utcnow()
+    d = datetime.datetime.now(tz=pytz.UTC)
     thirty_minutes = datetime.timedelta(hours = 0.5)
     for i in range(48):
         timestamp = d.ctime()

--- a/pysolar/solar.py
+++ b/pysolar/solar.py
@@ -20,7 +20,7 @@
 This module contains the most important functions for calculation of the position of the sun.
 
 """
-import math
+from . import numeric as math
 import datetime
 from . import constants
 from . import solartime as stime
@@ -34,7 +34,7 @@ def solar_test():
     longitude_deg = -71.112828
     d = datetime.datetime.now(tz=pytz.UTC)
     thirty_minutes = datetime.timedelta(hours = 0.5)
-    for i in range(48):
+    for _ in range(48):
         timestamp = d.ctime()
         altitude_deg = get_altitude(latitude_deg, longitude_deg, d)
         azimuth_deg = get_azimuth(latitude_deg, longitude_deg, d)
@@ -169,10 +169,10 @@ def get_azimuth_fast(latitude_deg, longitude_deg, when):
 
     azimuth_rad = math.asin(math.cos(declination_rad) * math.sin(hour_angle_rad) / math.cos(altitude_rad))
 
-    if(math.cos(hour_angle_rad) >= (math.tan(declination_rad) / math.tan(latitude_rad))):
-        return math.degrees(azimuth_rad)
-    else:
-        return (180 - math.degrees(azimuth_rad))
+    return math.where(math.cos(hour_angle_rad) >= (math.tan(declination_rad) / math.tan(latitude_rad)),
+                      math.degrees(azimuth_rad),
+                      (180 - math.degrees(azimuth_rad))
+                     )
 
 def get_coeff(jme, coeffs):
     "computes a polynomial with time-varying coefficients from the given constant" \
@@ -333,7 +333,7 @@ def get_refraction_correction(pressure, temperature, topocentric_elevation_angle
     # Better method could come from Auer and Standish [2000]:
     # http://iopscience.iop.org/1538-3881/119/5/2472/pdf/1538-3881_119_5_2472.pdf
     
-    if (tea >= -1.0*(sun_radius + atmos_refract)):
+    if math.all(tea >= -1.0*(sun_radius + atmos_refract)):
         a = pressure * 2.830 * 1.02
         b = 1010.0 * temperature * 60.0 * math.tan(math.radians(tea + (10.3/(tea + 5.11))))
         del_e = a / b

--- a/pysolar/util.py
+++ b/pysolar/util.py
@@ -30,7 +30,7 @@
 from datetime import \
     datetime, \
     timedelta
-import math
+from . import numeric as math
 from . import solar, constants
 from .tzinfo_check import check_aware_dt
 

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -1,0 +1,51 @@
+import pysolar
+from pysolar import solar
+from pysolar import numeric as math
+from datetime import datetime
+import pytz
+import numpy as np
+from nose.tools import raises
+
+
+@raises(TypeError)
+def test_fail_with_math():
+    pysolar.use_math()
+    lat = np.array([45., 40.])
+    lon = np.array([3., 4.])
+    time = datetime(2018, 5, 8, 12, 0, 0, tzinfo=pytz.UTC)
+
+    solar.get_altitude(lat, lon, time)
+
+
+def test_scalar_with_math():
+    pysolar.use_math()
+
+    lat = 45.
+    lon = 3.
+    time = datetime(2018, 5, 8, 12, 0, 0, tzinfo=pytz.UTC)
+
+    print(solar.get_altitude(lat, lon, time))
+    print(solar.get_azimuth(lat, lon, time))
+
+
+def test_scalar_with_numpy():
+    pysolar.use_numpy()
+
+    lat = 50.63
+    lon = 3.05
+    time = datetime(2018, 5, 8, 12, 0, 0, tzinfo=pytz.UTC)
+    print(solar.get_altitude(lat, lon, time))
+    print(solar.get_azimuth(lat, lon, time))
+
+
+def test_with_fixed_time():
+    """ get_altitude and get_azimuth, test with scalar date """
+    pysolar.use_numpy()
+
+    lat = np.array([45., 40.])
+    lon = np.array([3., 4.])
+
+    time = datetime(2018, 5, 8, 12, 0, 0, tzinfo=pytz.UTC)
+
+    print(solar.get_altitude(lat, lon, time))
+    print(solar.get_azimuth(lat, lon, time))


### PR DESCRIPTION
This is a first step towards #72, that I implemented for my needs.
Introduced the module numeric.py to include common functions between math and numpy, and some tools to help in the vectorization.
numpy is only an optional dependency, which allows to pass arrays of latitudes and longitudes to get_elevation and get_azimuth. However, times still can not be passed as arrays because some functions in solartime.py are not very straightforward to vectorize.
This approach could be extended to more functions in pysolar.

Let me know what you think of this approach.