### PR TITLE
solar.py: time vectorization of *_fast functions

### DIFF
--- a/pysolar/numeric.py
+++ b/pysolar/numeric.py
@@ -42,12 +42,50 @@ def globals_import_from(module, name, name_as):
     globals()[name_as] = getattr(module, name)
 
 
-def where(condition, x, y):
+def where_math(condition, x, y):
     """ scalar version of numpy.where """
     if condition:
         return x
     else:
         return y
+
+where = where_math
+
+
+def tm_yday_math(d):
+    return d.utctimetuple().tm_yday
+
+tm_yday = tm_yday_math
+
+
+def tm_yday_numpy(d):
+    dd = numpy.array(d, dtype='datetime64[D]')
+    dy = numpy.array(d, dtype='datetime64[Y]')
+    return (dd - dy).astype('int') + 1
+
+
+def tm_hour_math(d):
+    return d.utctimetuple().tm_hour
+
+tm_hour = tm_hour_math
+
+
+def tm_hour_numpy(d):
+    dh = numpy.array(d, dtype='datetime64[h]')
+    dd = numpy.array(d, dtype='datetime64[D]')
+    return (dh - dd).astype('int')
+
+
+def tm_min_math(d):
+    return d.utctimetuple().tm_min
+
+tm_min = tm_min_math
+
+
+def tm_min_numpy(d):
+    dm = numpy.array(d, dtype='datetime64[m]')
+    dh = numpy.array(d, dtype='datetime64[h]')
+    return (dm - dh).astype('int')
 
 
 def use_numpy():
@@ -67,7 +105,11 @@ def use_numpy():
     globals_import_from('numpy', 'exp', 'exp')
     globals_import_from('numpy', 'e', 'e')
     globals_import_from('numpy', 'where', 'where')
+    globals()['tm_yday'] = tm_yday_numpy
+    globals()['tm_hour'] = tm_hour_numpy
+    globals()['tm_min'] = tm_min_numpy
     globals()['current_mod'] = 'numpy'
+
 
 def use_math():
     """
@@ -86,7 +128,11 @@ def use_math():
     globals_import_from('math', 'exp', 'exp')
     globals_import_from('math', 'e', 'e')
     globals()['where'] = where
+    globals()['tm_yday'] = tm_yday_math
+    globals()['tm_hour'] = tm_hour_math
+    globals()['tm_min'] = tm_min_math
     globals()['current_mod'] = 'math'
+
 
 try:
     import numpy

--- a/pysolar/solar.py
+++ b/pysolar/solar.py
@@ -165,7 +165,7 @@ def get_azimuth_fast(latitude_deg, longitude_deg, when):
     declination_rad = math.radians(get_declination(day))
     latitude_rad = math.radians(latitude_deg)
     hour_angle_rad = math.radians(get_hour_angle(when, longitude_deg))
-    altitude_rad = math.radians(get_altitude(latitude_deg, longitude_deg, when))
+    altitude_rad = math.radians(get_altitude_fast(latitude_deg, longitude_deg, when))
 
     azimuth_rad = math.asin(math.cos(declination_rad) * math.sin(hour_angle_rad) / math.cos(altitude_rad))
 

--- a/pysolar/solar.py
+++ b/pysolar/solar.py
@@ -130,7 +130,7 @@ def get_altitude(latitude_deg, longitude_deg, when, elevation = 0,
 @check_aware_dt('when')
 def get_altitude_fast(latitude_deg, longitude_deg, when):
 # expect 19 degrees for solar.get_altitude(42.364908,-71.112828,datetime.datetime(2007, 2, 18, 20, 13, 1, 130320))
-    day = when.utctimetuple().tm_yday
+    day = math.tm_yday(when)
     declination_rad = math.radians(get_declination(day))
     latitude_rad = math.radians(latitude_deg)
     hour_angle = get_hour_angle(when, longitude_deg)
@@ -161,7 +161,7 @@ def get_azimuth(latitude_deg, longitude_deg, when, elevation = 0):
 
 def get_azimuth_fast(latitude_deg, longitude_deg, when):
 # expect -50 degrees for solar.get_azimuth(42.364908,-71.112828,datetime.datetime(2007, 2, 18, 20, 18, 0, 0))
-    day = when.utctimetuple().tm_yday
+    day = math.tm_yday(when)
     declination_rad = math.radians(get_declination(day))
     latitude_rad = math.radians(latitude_deg)
     hour_angle_rad = math.radians(get_hour_angle(when, longitude_deg))
@@ -344,10 +344,9 @@ def get_refraction_correction(pressure, temperature, topocentric_elevation_angle
 def get_solar_time(longitude_deg, when):
     "returns solar time in hours for the specified longitude and time," \
     " accurate only to the nearest minute."
-    when = when.utctimetuple()
     return \
         (
-            (when.tm_hour * 60 + when.tm_min + 4 * longitude_deg + equation_of_time(when.tm_yday))
+            (math.tm_hour(when) * 60 + math.tm_min(when) + 4 * longitude_deg + equation_of_time(math.tm_yday(when)))
         /
             60
         )

--- a/pysolar/tzinfo_check.py
+++ b/pysolar/tzinfo_check.py
@@ -83,12 +83,13 @@ def check_aware_dt(*argnames):
           except (IndexError, ValueError):
             dt = kwargs[argname]
           # checking if dt is timezone-aware
-          if not hasattr(dt, 'tzinfo'):
-            raise ValueError(
-              "Expected a 'datetime.datetime' object \
-  for arg '%s', got %s instead" % (argname, dt))
-          if dt.tzinfo is None:
-            raise NoTimeZoneInfoError(argname, dt)
+          if not hasattr(dt, 'shape'):   # don't raise Exception if dt is an array (assumed of datetime64)
+            if not hasattr(dt, 'tzinfo'):
+              raise ValueError(
+                "Expected a 'datetime.datetime' object \
+    for arg '%s', got %s instead" % (argname, dt))
+            if dt.tzinfo is None:
+              raise NoTimeZoneInfoError(argname, dt)
       return func(*args, **kwargs)
     return func_with_check
   return checker

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -4,7 +4,7 @@ from pysolar import numeric as math
 from datetime import datetime
 import pytz
 import numpy as np
-from nose.tools import raises
+from nose.tools import raises, assert_equal
 
 
 @raises(TypeError)
@@ -39,7 +39,7 @@ def test_scalar_with_numpy():
 
 
 def test_with_fixed_time():
-    """ get_altitude and get_azimuth, test with scalar date """
+    """ get_altitude and get_azimuth, with scalar date """
     pysolar.use_numpy()
 
     lat = np.array([45., 40.])
@@ -49,3 +49,47 @@ def test_with_fixed_time():
 
     print(solar.get_altitude(lat, lon, time))
     print(solar.get_azimuth(lat, lon, time))
+    print(solar.get_altitude_fast(lat, lon, time))
+    print(solar.get_azimuth_fast(lat, lon, time))
+
+
+def test_with_fixed_position():
+    """ get_altitude and get_azimuth, with scalar position """
+    pysolar.use_numpy()
+
+    lat = 50.
+    lon = 3.
+
+    time = np.array(['2018-05-08T12:15:00',
+                     '2018-05-08T15:00:00'], dtype='datetime64')
+
+    print(solar.get_altitude_fast(lat, lon, time))
+    print(solar.get_azimuth_fast(lat, lon, time))
+
+def test_datetime_operations():
+
+    d0 = datetime(2018,5,8,12,0,0)
+    d1 = np.array(d0)
+
+    assert_equal(math.tm_yday_math(d0),
+                 math.tm_yday_numpy(d1))
+
+    assert_equal(math.tm_hour_math(d0),
+                 math.tm_hour_numpy(d1))
+
+    assert_equal(math.tm_min_math(d0),
+                 math.tm_min_numpy(d1))
+
+
+def test_numpy():
+    """ get_altitude and get_azimuth, with lat, lon and date arrays """
+    pysolar.use_numpy()
+
+    lat = np.array([45., 40.])
+    lon = np.array([3., 4.])
+
+    time = np.array(['2018-05-08T12:15:00',
+                     '2018-05-08T15:00:00'], dtype='datetime64')
+
+    print(solar.get_altitude_fast(lat, lon, time))
+    print(solar.get_azimuth_fast(lat, lon, time))


### PR DESCRIPTION
This allows applying `get_altitude_fast` and `get_azimuth_fast` to numpy datetime64 arrays.