### PR TITLE
Fix #97 -- Raise ImportError

### DIFF
--- a/pysolar/numeric.py
+++ b/pysolar/numeric.py
@@ -137,6 +137,5 @@ def use_math():
 try:
     import numpy
     use_numpy()
-except ModuleNotFoundError:
+except ImportError:
     pass
-


### PR DESCRIPTION
ModuleNotFoundError was introduced in Python 3.6 as a more specific
subclass of ImportError. We need to fall back to the more generic
ImportError to ensure Python 3.5 and 3.4 compatibility.