### PR TITLE
Changes to Clearness index function which should return  values between 0 and 1

### DIFF
--- a/pysolar/util.py
+++ b/pysolar/util.py
@@ -686,7 +686,10 @@ def clear_index(ghi_data, latitude_deg, longitude_deg, when):
 
     """
     EXTR1 = extraterrestrial_irrad(latitude_deg, longitude_deg, when)
-
-    KT = (ghi_data / EXTR1)
-
+    try:
+        KT = (ghi_data / EXTR1)
+        if KT > 1:
+            KT = 1
+    except ZeroDivisionError:
+        return 0
     return KT


### PR DESCRIPTION
It seems in some scenarios i observed `KT > 1` and `ZeroDivisionError`. So these changes might help.