### PR TITLE
Revert "Changes to Clearness index function which should return  values between 0 and 1"

### DIFF
--- a/pysolar/util.py
+++ b/pysolar/util.py
@@ -686,10 +686,7 @@ def clear_index(ghi_data, latitude_deg, longitude_deg, when):
 
     """
     EXTR1 = extraterrestrial_irrad(latitude_deg, longitude_deg, when)
-    try:
-        KT = (ghi_data / EXTR1)
-        if KT > 1:
-            KT = 1
-    except ZeroDivisionError:
-        return 0
+
+    KT = (ghi_data / EXTR1)
+
     return KT


### PR DESCRIPTION
Reverts pingswept/pysolar#104

This broke the build with this error on Python 3.4:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()