### PR TITLE
Make get_radiation_direct handle NumPy arrays

### DIFF
--- a/pysolar/radiation.py
+++ b/pysolar/radiation.py
@@ -42,11 +42,10 @@ def get_optical_depth(day):
 
 def get_radiation_direct(when, altitude_deg):
     # from Masters, p. 412
-    if int(altitude_deg) <= 0:
-        return 0.0
-    day = when.utctimetuple().tm_yday
+    is_daytime = (altitude_deg > 0)
+    day = math.tm_yday(when)
     flux = get_apparent_extraterrestrial_flux(day)
     optical_depth = get_optical_depth(day)
     air_mass_ratio = get_air_mass_ratio(altitude_deg)
-    return flux * math.exp(-1 * optical_depth * air_mass_ratio)
+    return flux * math.exp(-1 * optical_depth * air_mass_ratio) * is_daytime
 #end get_radiation_direct

--- a/test/test_numpy.py
+++ b/test/test_numpy.py
@@ -1,5 +1,5 @@
 import pysolar
-from pysolar import solar
+from pysolar import radiation, solar
 from pysolar import numeric as math
 from datetime import datetime
 import pytz
@@ -93,3 +93,24 @@ def test_numpy():
 
     print(solar.get_altitude_fast(lat, lon, time))
     print(solar.get_azimuth_fast(lat, lon, time))
+
+
+def test_numpy_radiation():
+    """
+    get_radiation_direct with lat, lon, and date as arrays
+    """
+    pysolar.use_numpy()
+
+    lat = np.array([45., 40., 40.])
+    lon = np.array([3., 4., 3.])
+
+    time = np.array([
+        '2018-05-08T12:15:00',
+        '2018-05-08T15:00:00',
+        '2018-05-08T03:00:00',
+    ], dtype='datetime64')
+
+    altitude = solar.get_altitude_fast(lat, lon, time)
+    rad_results = radiation.get_radiation_direct(time, altitude)
+    assert rad_results[2] == 0
+    print(rad_results)


### PR DESCRIPTION
As another increment toward issue #72, I got `get_radiation_direct` to work with NumPy arrays as inputs.

The existing tests pass on the Python interpreter I was using (3.7.0), and I added a new test to exercise the new functionality.