### PR TITLE
Revert "Fix get_sunrise_sunset_transit() function name in example"

### DIFF
--- a/pysolar/util.py
+++ b/pysolar/util.py
@@ -82,7 +82,7 @@ def get_sunrise_sunset_transit(latitude_deg, longitude_deg, when):
     >>> lon = 8.680506
     >>> timezone_local = pytz.timezone('Europe/Berlin')
     >>> now = datetime.now(timezone_local)
-    >>> sr, ss, tr = sb.get_sunrise_sunset_transit(lat, lon, now)
+    >>> sr, ss, tr = sb.get_sunrise_sunset(lat, lon, now)
     >>> print('sunrise: ', sr)
     >>> print('sunset:', ss)
     >>> print('transit:', tr)


### PR DESCRIPTION
Reverts pingswept/pysolar#117

This patch breaks the build for Python 3.7, but only for some silly reason. I'll sort this out eventually. The problem is with the build test, not the patch.