### PR TITLE
Removed dependency on pytz library

### DIFF
--- a/pysolar/solar.py
+++ b/pysolar/solar.py
@@ -26,13 +26,12 @@ from . import constants
 from . import solartime as stime
 from . import radiation
 from .tzinfo_check import check_aware_dt
-import pytz
 
 
 def solar_test():
     latitude_deg = 42.364908
     longitude_deg = -71.112828
-    d = datetime.datetime.now(tz=pytz.UTC)
+    d = datetime.datetime.now(datetime.timezone.utc)
     thirty_minutes = datetime.timedelta(hours = 0.5)
     for _ in range(48):
         timestamp = d.ctime()


### PR DESCRIPTION
Now using standard library `datetime` (already imported) to get UTC time; see https://docs.python.org/3/library/datetime.html#datetime.datetime.now

The (undocumented) dependency on `pytz` is removed