### PR TITLE
Final changes to completely remove dependency on pytz

### DIFF
--- a/.github/workflows/testpackage.yml
+++ b/.github/workflows/testpackage.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
+        pip install flake8 nose pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -27,6 +27,7 @@ Thanks to:
 * Robin Wilson
 * Pietro Zambelli
 * Holger Zebner
+* Mike Borsetti
 
 for their contributions of code, bugfixes, documentation, and general encouragement.
 

--- a/pysolar/solar.py
+++ b/pysolar/solar.py
@@ -26,13 +26,12 @@ from . import constants
 from . import solartime as stime
 from . import radiation
 from .tzinfo_check import check_aware_dt
-import pytz
 
 
 def solar_test():
     latitude_deg = 42.364908
     longitude_deg = -71.112828
-    d = datetime.datetime.now(tz=pytz.UTC)
+    d = datetime.datetime.now(tz=datetime.timezone.utc)
     thirty_minutes = datetime.timedelta(hours = 0.5)
     for _ in range(48):
         timestamp = d.ctime()

--- a/python3-pysolar.spec
+++ b/python3-pysolar.spec
@@ -25,9 +25,7 @@ BuildRequires:  make
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-sphinx
-BuildRequires:  python3-nose
 BuildRequires:  python3-numpy
-BuildRequires:  python3-pytz
 
 Provides:       python3-%{srcname} = %{version}-%{release}
 %{?python_provide:%python_provide python3-%{pkgname}}
@@ -64,7 +62,7 @@ popd
 %changelog
 * Fri Jun 19 2020 Johan Heikkila <johan.heikkila@gmail.com> - 0.8-2
 - Removed python2
-- Added BuildRequires python3-nose, python3-numpy
+- Added BuildRequires python3-numpy
 
 * Mon Sep 16 2019 Elliot Lee <sopwith@gmail.com> - 0.8-1
 - Initial version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-pytz
 numpy
-nose

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ setup(name='pysolar',
     url='http://pysolar.org',
     packages=['pysolar'],
     package_data = {"pysolar": ["*.pyi"]},  # *.py is included in any case
-    requires = ['numpy', 'pytz'],
+    requires = ['numpy'],
     )


### PR DESCRIPTION
Final cleanup to remove unneded dependencies.

Also `nose` is not a dependency to run the installed package as it's exclusively used in `test/test_numpy.py`.