### PR TITLE
Fix numpy deprecation

### DIFF
--- a/pysolar/numeric.py
+++ b/pysolar/numeric.py
@@ -30,6 +30,7 @@ To force builtins math module usage when numpy is available:
 
 from math import degrees, cos, sin, radians, tan, pi
 from math import acos, atan, asin, atan2, exp, e
+import datetime
 
 current_mod = 'math'
 
@@ -59,6 +60,7 @@ tm_yday = tm_yday_math
 
 
 def tm_yday_numpy(d):
+    d = d.astimezone(tz=datetime.timezone.utc).replace(tzinfo=None)
     dd = numpy.array(d, dtype='datetime64[D]')
     dy = numpy.array(d, dtype='datetime64[Y]')
     return (dd - dy).astype('int') + 1
@@ -71,6 +73,7 @@ tm_hour = tm_hour_math
 
 
 def tm_hour_numpy(d):
+    d = d.astimezone(tz=datetime.timezone.utc).replace(tzinfo=None)
     dh = numpy.array(d, dtype='datetime64[h]')
     dd = numpy.array(d, dtype='datetime64[D]')
     return (dh - dd).astype('int')
@@ -83,6 +86,7 @@ tm_min = tm_min_math
 
 
 def tm_min_numpy(d):
+    d = d.astimezone(tz=datetime.timezone.utc).replace(tzinfo=None)
     dm = numpy.array(d, dtype='datetime64[m]')
     dh = numpy.array(d, dtype='datetime64[h]')
     return (dm - dh).astype('int')


### PR DESCRIPTION
When running tests I saw repeated warnings from `numpy` (current version):

> `DeprecationWarning: parsing timezone aware datetimes is deprecated; this will raise an error in the future`

The documentation at https://numpy.org/devdocs/reference/arrays.datetime.html#basic-datetimes warns:

> Deprecated since version 1.11.0: NumPy does not store timezone information. For backwards compatibility, datetime64 still parses timezone offsets, which it handles by converting to UTC. This behaviour is deprecated and will raise an error in the future

This patch converts datetimes to UTC and strips them of the timezone information before they're fed into numpy. All unit tests pass.