### PR TITLE
get_sunrise_sunset_transit referred to UTC not to local time

### DIFF
--- a/pysolar/util.py
+++ b/pysolar/util.py
@@ -95,7 +95,7 @@ def get_sunrise_sunset_transit(latitude_deg, longitude_deg, when):
     else :
         utc_offset = 0
     #end if
-    day = when.utctimetuple().tm_yday # Day of the year
+    day = when.timetuple().tm_yday # Day of the year
     SHA = utc_offset / 3600 * 15.0 - longitude_deg # Solar hour angle
     TT = 2 * math.pi * day / 366
     decl = \


### PR DESCRIPTION
Hi, I've been using the get_sunrise_sunset_transit function to calculate the sunrise, sunset and transit time in my current location, using my local timezone.
The problem is that this function calculates the sunrise, sunset and transit time of the UTC day in local time, but would be more logic to calculate the sunrise, sunset and transit time of the current local day in local time.
For example:
I'm in Madrid timezone (+1), and when I calculate the sunrise time at local time 29/11/2020_00:30:00 (UTC 28/11/2020_23:30:00) it correctly gives me back the sunrise time in local time, but from the day 28 not from the 29.

I've removed 'utc' from 'utctimetuple()' which gets rid of that behavior. 
I don't really know if this behavior has been implemented on purpose but for the current program I'm making it makes no sense.
Thanks