### PR TITLE
Add leap second information for 2022

### DIFF
--- a/pysolar/solartime.py
+++ b/pysolar/solartime.py
@@ -89,6 +89,7 @@ leap_seconds_adjustments = \
       (0, 0),  # 2019
       (0, 0),  # 2020
       (0, 0),  # 2021
+      (0, 0),  # 2022
     ]
 
 @check_aware_dt('when')


### PR DESCRIPTION
I've added leap second information for 2022 as per the [NIST page](https://www.nist.gov/pml/time-and-frequency-division/atomic-standards/leap-second-and-ut1-utc-information) you referenced.