### PR TITLE
Use install_requires keyword in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ setup(name='pysolar',
     url='http://pysolar.org',
     packages=['pysolar'],
     package_data = {"pysolar": ["*.pyi"]},  # *.py is included in any case
-    requires = ['numpy'],
+    install_requires = ['numpy'],
     )


### PR DESCRIPTION
`requires` is superseded by `install_requires` and should not be used anymore. 
Reference: https://setuptools.pypa.io/en/latest/references/keywords.html