### PR TITLE
Leap Second for 2024

### DIFF
--- a/pysolar/solartime.py
+++ b/pysolar/solartime.py
@@ -91,6 +91,7 @@ leap_seconds_adjustments = \
       (0, 0),  # 2021
       (0, 0),  # 2022
       (0, 0), # 2023
+      (0, 0), # 2024      
     ]
 
 @check_aware_dt('when')


### PR DESCRIPTION
No leap second introduced. Next likely update : December 31, 2024.