### PR TITLE
Leap second for 2025

### DIFF
--- a/pysolar/solartime.py
+++ b/pysolar/solartime.py
@@ -92,6 +92,7 @@ leap_seconds_adjustments = \
       (0, 0),  # 2022
       (0, 0), # 2023
       (0, 0), # 2024      
+      (0, 0), # 2025      
     ]
 
 @check_aware_dt('when')


### PR DESCRIPTION
No leap second for 2025 was introduced on 31/12/2024. Next possible update date is June 30, 2025.