### PR TITLE
Fixes link to XEphem

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,7 +11,7 @@ Pysolar is a collection of Python libraries for simulating the irradiation of an
 Difference from PyEphem
 -----------------------
 
-Pysolar is similar to `PyEphem <http://rhodesmill.org/pyephem/>`_, with a few key differences. Both libraries compute the location of the sun based on `Bretagnon's VSOP 87 theory <http://articles.adsabs.harvard.edu/cgi-bin/nph-iarticle_query?1988A%26A...202..309B>`_. Pysolar is aimed at modeling photovoltaic systems, while PyEphem is targeted at astronomers. Pysolar is written in pure Python, while PyEphem is a Python wrapper for the libastro library, written in C, which is part of `XEphem <http://www.clearskyinstitute.com/xephem/>`_.
+Pysolar is similar to `PyEphem <http://rhodesmill.org/pyephem/>`_, with a few key differences. Both libraries compute the location of the sun based on `Bretagnon's VSOP 87 theory <http://articles.adsabs.harvard.edu/cgi-bin/nph-iarticle_query?1988A%26A...202..309B>`_. Pysolar is aimed at modeling photovoltaic systems, while PyEphem is targeted at astronomers. Pysolar is written in pure Python, while PyEphem is a Python wrapper for the libastro library, written in C, which is part of `XEphem <https://xephem.github.io/XEphem/Site/xephem>`_.
 
 Difference from Sunpy
 ---------------------


### PR DESCRIPTION
Changes `http://www.clearskyinstitute.com/xephem` to `https://xephem.github.io/XEphem/Site/xephem`.

Cheers, Tom